### PR TITLE
Fix warnings emitted when building Composer image

### DIFF
--- a/docker/composer/Dockerfile
+++ b/docker/composer/Dockerfile
@@ -3,8 +3,14 @@ FROM composer/composer
 COPY etc/apt/sources.list.d/stable.list /etc/apt/sources.list.d/stable.list
 COPY etc/apt/sources.list.d/testing.list /etc/apt/sources.list.d/testing.list
 
-RUN apt-get update
-RUN apt-get install php7.0-bcmath php7.0-intl -y
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EF0F382A1A7B6500
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get remove -y binutils && \
+    apt-get install -y git php7.0-bcmath php7.0-intl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY usr/local/etc/php/conf.d/docker-php-ext-bcmath.ini /usr/local/etc/php/conf.d/docker-php-ext-bcmath.ini
 COPY usr/local/etc/php/conf.d/docker-php-ext-intl.ini /usr/local/etc/php/conf.d/docker-php-ext-intl.ini


### PR DESCRIPTION
**NOTE:** Instead of fixing a custom Composer image, maybe it's better to adopt [the official image](https://hub.docker.com/r/library/composer/) instead?

----

This PR fixes a few things that happen when building the Composer image:

**1. APT fails for two source updates due to invalid keys**
```
W: There is no public key available for the following key IDs:
04EE7237B7D453EC
W: There is no public key available for the following key IDs:
EF0F382A1A7B6500
```
**2. When fixing those keys, libc6-dev package requirements breaks binutils:**
```
 libc6-dev : Breaks: binutils (< 2.26) but 2.25-5 is to be installed
```
We don't need it, so get rid of it.

**3. Furthermore:**
- Frontend not set, so run APT noninteractive
- git was missing (for Composer)

