### PR TITLE
TIHA-5 - View the generated password

### DIFF
--- a/src/reloaddk/HarvesterBundle/Controller/AdminController.php
+++ b/src/reloaddk/HarvesterBundle/Controller/AdminController.php
@@ -134,7 +134,7 @@ class AdminController
             if ($this->mailer->sendMail('harvest@reload.dk', $user->getEmail(), $user->getFirstname(), $user_password, 'Hello Email')) {
                 $this->session->getFlashBag()->add(
                     'success',
-                    'New password for <strong>' . $user->getFirstname() . ' ' . $user->getLastname() . '</strong> is generated.'
+                    'New password <strong>' . $user_password . '</strong> for <strong>' . $user->getFirstname() . ' ' . $user->getLastname() . '</strong> is generated.'
                 );
             }
         }


### PR DESCRIPTION
As of right now the password gets sent to the appropriate email and that might be enough but we really want to ease the usage of this feature and make it a bit more error resilient. The new deployment does not seems to let mail work so this is basically an escape hatch.

The is a new security vector for sure but then again. We already have the option to explicitly set a password.

https://reload.atlassian.net/browse/TIHA-5