### PR TITLE
Pin composer to old version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Our dependencies ore too old for Composer 2
+FROM composer:1 AS composer
 FROM phusion/baseimage:0.9.17
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -16,15 +18,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 COPY ./ /harvester
 
+# Composer for building Harvester.
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
 # REST service app requires mod_rewrite.
 RUN a2enmod rewrite && \
-    # Composer for building Harvester.
-    curl -o /tmp/composer-installer https://getcomposer.org/installer && \
-    curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
-    php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
-    php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
-    php -r "unlink('/tmp/composer-installer');" && \
-    php -r "unlink('/tmp/composer-installer.sig');" && \
     # Link in
     rm -rf /var/www/html && \
     ln -s /harvester/web /var/www/html && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ COPY ./ /harvester
 # REST service app requires mod_rewrite.
 RUN a2enmod rewrite && \
     # Composer for building Harvester.
-    curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer && \
+    curl -o /tmp/composer-installer https://getcomposer.org/installer && \
+    curl -o /tmp/composer-installer.sig https://composer.github.io/installer.sig &&  \
+    php -r "if (hash('SHA384', file_get_contents('/tmp/composer-installer')) !== trim(file_get_contents('/tmp/composer-installer.sig'))) { unlink('/tmp/composer-installer'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+    php /tmp/composer-installer --version=1.6.5 --filename=composer --install-dir=/usr/local/bin && \
+    php -r "unlink('/tmp/composer-installer');" && \
+    php -r "unlink('/tmp/composer-installer.sig');" && \
     # Link in
     rm -rf /var/www/html && \
     ln -s /harvester/web /var/www/html && \


### PR DESCRIPTION
Pin to old composer.

Composer 2 fails due to odd failure cloning a repo. V1 errors too, but manages to download a dist package instead. Both  complain about deprecated usage and abandoned packages.

Actually updating anything is a lost cause. It's a Symfony 2 app, and bundles has been replaced by Symfony Flex. It's basically a rewrite, and then one might consider more elegant frameworks.